### PR TITLE
fixed synchronization when removing or adding products in retailCRM

### DIFF
--- a/src/upload/system/library/retailcrm/RetailcrmHistoryHelper.php
+++ b/src/upload/system/library/retailcrm/RetailcrmHistoryHelper.php
@@ -93,7 +93,7 @@ class RetailcrmHistoryHelper {
     {
         $customers = array();
         foreach ($customerHistory as $change) {
-            $change['order'] = self::removeEmpty($change['customer']);
+            $change['customer'] = self::removeEmpty($change['customer']);
 
             if(!empty($customers[$change['customer']['id']]) && $customers[$change['customer']['id']]) {
                 $customers[$change['customer']['id']] = array_merge($customers[$change['customer']['id']], $change['customer']);

--- a/src/upload/system/library/retailcrm/RetailcrmHistoryHelper.php
+++ b/src/upload/system/library/retailcrm/RetailcrmHistoryHelper.php
@@ -41,15 +41,13 @@ class RetailcrmHistoryHelper {
                     $orders[$change['order']['id']]['items'][$change['item']['id']] = $change['item'];
                 }
 
-                if (isset($change['oldValue'])
-                    && empty($change['oldValue'])
+                if (empty($change['oldValue'])
                     && $change['field'] == 'order_product'
                 ) {
                     $orders[$change['order']['id']]['items'][$change['item']['id']]['create'] = true;
                 }
 
-                if (isset($change['newValue'])
-                    && empty($change['newValue'])
+                if (empty($change['newValue'])
                     && $change['field'] == 'order_product'
                 ) {
                     $orders[$change['order']['id']]['items'][$change['item']['id']]['delete'] = true;


### PR DESCRIPTION
Исправлена ошибка, при которой в случае, если удалить или добавить товар в retailCRM, он не добавится в opencart, т.к. по логике php проверка через isset наличия ключа со значением null вернет false, а не true как ожидается, кроме того проверка наличия данных ключей избыточна, т.к. в участке истории в любом случае они должны присутствовать.