### PR TITLE
fix opencart reward to crm discount convert error

### DIFF
--- a/src/upload/system/library/retailcrm/lib/service/RetailcrmOrderConverter.php
+++ b/src/upload/system/library/retailcrm/lib/service/RetailcrmOrderConverter.php
@@ -86,7 +86,7 @@ class RetailcrmOrderConverter {
         }
 
         if ($discount > 0) {
-            $order['discountManualAmount'] = $discount;
+            $this->data['discountManualAmount'] = $discount;
         }
 
         return $this;


### PR DESCRIPTION
Opencart Version 2.3.0.2 (rs.6) , версия модуя 4.0.0
Некорректно обрабатывает бонусы при заказе - не передает их в црм в качестве скидки по заказу.
Удалось исправить, скорректировав переменную, которой присваивается рассчитанная скидка. Т.к. переменной $order в данном методе нет.