### PR TITLE
fix empty payments update after checkout

### DIFF
--- a/src/upload/catalog/controller/extension/module/retailcrm.php
+++ b/src/upload/catalog/controller/extension/module/retailcrm.php
@@ -114,8 +114,8 @@ class ControllerExtensionModuleRetailcrm extends Controller {
 
             if (file_exists(DIR_APPLICATION . 'model/extension/retailcrm/custom/order.php')) {
                 $this->load->model('extension/retailcrm/custom/order');
-                $data['products'] = $products;
-                $data['totals'] = $totals;
+                $data['products'] = $data['products'] ? $data['products'] : $products;
+                $data['totals'] = $data['totals'] ? $data['totals'] : $totals;
 
                 $order = $this->model_extension_retailcrm_custom_order->processOrder($data, false);
                 $this->model_extension_retailcrm_custom_order->sendToCrm($order, $this->retailcrmApiClient, $data, false);


### PR DESCRIPTION
В $products и $totals не всегда есть данные, иногда там пусто и они стирают данные в $data['products'] и $data['totals']