### PR TITLE
fix version file path

### DIFF
--- a/src/upload/system/library/retailcrm/cron/dispatch.php
+++ b/src/upload/system/library/retailcrm/cron/dispatch.php
@@ -12,7 +12,7 @@ if (!isset($cli_action)) {
 
 // Version
 $version = '2.3.0';
-$indexFile = file_get_contents(realpath(dirname(__FILE__)) . '/../../index.php');
+$indexFile = file_get_contents(realpath(dirname(__FILE__)) . '/../../../../index.php');
 preg_match("/define\([\s]*['\"]VERSION['\"][\s]*,[\s]*['\"](.*)['\"][\s]*\)[\s]*;/mi", $indexFile, $versionMatches);
 
 if (isset($versionMatches[1])) {


### PR DESCRIPTION
Индексный файл, из которого берется версия CMS, находится на два уровня выше.

Схожий фикс был в коммите https://github.com/retailcrm/opencart-module/commit/85de4835d545f6ccdae623854ac2af7f42059b1c