### PR TITLE
fix api version checks

### DIFF
--- a/src/upload/admin/controller/extension/module/retailcrm.php
+++ b/src/upload/admin/controller/extension/module/retailcrm.php
@@ -371,7 +371,7 @@ class ControllerExtensionModuleRetailcrm extends Controller
             $_data['payments'] = $this->model_extension_retailcrm_references
                 ->getPaymentTypes();
 
-            if ($apiVersion == 'v5') {
+            if (!$apiVersion || $apiVersion == 'v5') {
                 $_data['customFields'] = $this->model_extension_retailcrm_references
                     ->getCustomFields();
             }

--- a/src/upload/admin/model/extension/retailcrm/prices.php
+++ b/src/upload/admin/model/extension/retailcrm/prices.php
@@ -60,7 +60,11 @@ class ModelExtensionRetailcrmPrices extends Model
         $prices = array();
         $site = $this->getSite($retailcrmApiClient);
 
-        if ($this->settings[$this->moduleTitle . '_apiversion'] == 'v3') {
+        $apiVersion = isset($this->settings[$this->moduleTitle . '_apiversion'])
+            ? $this->settings[$this->moduleTitle . '_apiversion']
+            : null;
+
+        if ($apiVersion && $apiVersion == 'v3') {
             return false;
         }
 

--- a/src/upload/catalog/model/extension/retailcrm/order.php
+++ b/src/upload/catalog/model/extension/retailcrm/order.php
@@ -68,7 +68,11 @@ class ModelExtensionRetailcrmOrder extends Model {
                 $response = $retailcrmApiClient->ordersEdit($order);
             }
 
-            if ($this->settings[$this->moduleTitle . '_apiversion'] == 'v5' && $response->isSuccessful()) {
+            $apiVersion = isset($this->settings[$this->moduleTitle . '_apiversion'])
+                ? $this->settings[$this->moduleTitle . '_apiversion']
+                : null;
+
+            if ((!$apiVersion || $apiVersion == 'v5') && $response->isSuccessful()) {
                 $this->updatePayment($order_payment, $order['externalId'], $retailcrmApiClient);
             }
         }
@@ -170,7 +174,11 @@ class ModelExtensionRetailcrmOrder extends Model {
 
         $order['createdAt'] = $order_data['date_added'];
 
-        if ($this->settings[$this->moduleTitle . '_apiversion'] != 'v5') {
+        $apiVersion = isset($this->settings[$this->moduleTitle . '_apiversion'])
+            ? $this->settings[$this->moduleTitle . '_apiversion']
+            : null;
+
+        if ($apiVersion && $apiVersion != 'v5') {
             $order['paymentType'] = $payment_code;
             if ($couponTotal > 0) {
                 $order['discount'] = $couponTotal;
@@ -245,7 +253,7 @@ class ModelExtensionRetailcrmOrder extends Model {
                 $offerId = implode('_', $offerId);
             }
 
-            if ($this->settings[$this->moduleTitle . '_apiversion'] != 'v3') {
+            if (!$apiVersion || $apiVersion != 'v3') {
                 $item = array(
                     'offer' => array(
                         'externalId' => !empty($offerId) ? $product['product_id'].'#'.$offerId : $product['product_id']


### PR DESCRIPTION
При кастомизации модуля, конкретно при копирования файла в /catalog/model/extension/retailcrm/custom/order.php, в CRM перестали передаваться купоны/бонусы.

Вероятно это связано с проверкой на версию API.

С версии 4.0.0 а Адимн.панеле Opencart пропала настройка "Версия API".
Соответственно при установке модуля в базе больше нет настройки "retailcrm_apiversion".
Но в коде остались места где эта настройка используется.
Т.к., по умолчанию, предполагается что версия api - "v5", то добавлены соответствующие проверки.